### PR TITLE
Updating GnuTLS cipher suits to not use ssl3, rc4, md5, or 3des.

### DIFF
--- a/apache/apache.conf.in
+++ b/apache/apache.conf.in
@@ -45,7 +45,8 @@
     ErrorLog            @PREFIX@/logs/error.log
 
     GnuTLSEnable On
-    GnuTLSPriorities NORMAL
+	# http://blog.lighttpd.net/gnutls-priority-strings.html
+    GnuTLSPriorities PFS:-VERS-SSL3.0:-VERS-TLS1.0:+SHA256:-MD5:-SHA1:-3DES-CBC:-ARCFOUR-128
     #GnuTLSPriorities NORMAL:+COMP-NULL
     GnuTLSKeyFile           @PREFIX@/server.key
     GnuTLSCertificateFile   @PREFIX@/server.crt

--- a/apache/vhost.conf
+++ b/apache/vhost.conf
@@ -48,8 +48,8 @@
 #    ErrorLog	    /srv/www/example.com/logs/error.log
 
     GnuTLSEnable On
-    GnuTLSPriorities NORMAL
-    #GnuTLSPriorities NORMAL:+COMP-NULL
+	# http://blog.lighttpd.net/gnutls-priority-strings.html
+    GnuTLSPriorities PFS:-VERS-SSL3.0:-VERS-TLS1.0:+SHA256:-MD5:-SHA1:-3DES-CBC:-ARCFOUR-128
     GnuTLSKeyFile	    /srv/www/certs/example.com.key
     GnuTLSCertificateFile   /srv/www/certs/example.com.crt
 </VirtualHost>


### PR DESCRIPTION
Similar to my past PR, but I forgot GnuTLS last time. To check what I changed, this website was able to show what the cipher suite string now contains.

http://blog.lighttpd.net/gnutls-priority-strings.html
